### PR TITLE
Build makes Perl scripts in bin with two !# lines in first and second line of scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,35 +145,35 @@ $(BIN) :
 
 $(addprefix $(BIN)/, $(CEGMA)) : $(addprefix $(SRC)/, $(CEGMA).pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL) -w"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 $(addprefix $(BIN)/, $(LOCAL_MAP)) : $(addprefix $(SRC)/, $(LOCAL_MAP).pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL) -w"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 $(addprefix $(BIN)/, $(GENOME_MAP)) : $(addprefix $(SRC)/, $(GENOME_MAP).pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL) -w"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 $(addprefix $(BIN)/, parsewise) : $(addprefix $(SRC)/, parsewise.pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL) -w"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 $(addprefix $(BIN)/, hmm_select) : $(addprefix $(SRC)/, hmm_select.pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL) -w"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 $(addprefix $(BIN)/, completeness) : $(addprefix $(SRC)/, completeness.pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL) -w"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 $(addprefix $(BIN)/, geneid-train) : $(addprefix $(SRC)/, geneid-train.pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL)"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 $(addprefix $(BIN)/, make_paramfile) : $(addprefix $(SRC)/, make_paramfile.pl)
 	@echo "### Finishing PERL script from \"$<\" -> \"$@\"" ;
-	@( echo "#!$(PERL) -w"; cat $< ) > $@;
+	@(sed '1c\#!$(PERL)' $<) > $@
 
 
 isexec : $(BINCODE)


### PR DESCRIPTION
When I run 'make', the files generated in bin all have a second line that was the original first line when they were in src.

Example:
$ head -4 src/cegma.pl
# !/usr/bin/perl
###### 
# 

$ head -4 bin/cegma
# !/usr/bin/perl -w
# !/usr/bin/perl
###### 

$

While this does not appear to have any effect (at least on my machine), it is clearly not the intent to have this second line here.

This is due to the Makefile which is prepending $(PERL) to the files, instead of replacing the first line.
I fixed this by replacing:
@( echo "#!$(PERL) -w"; cat $< ) > $@;
with
sed '1c#!$(PERL)' $< > $@

Note that the “-w” is not needed as all the Perl scripts “use warnings”.
